### PR TITLE
46 Add third status to inactive filter

### DIFF
--- a/app/[sheetId]/List.tsx
+++ b/app/[sheetId]/List.tsx
@@ -14,6 +14,7 @@ import { orderBy } from 'lodash'
 import { SEPARATOR } from '@/lib/constants'
 import { RelistItem } from '@/lib/relistData'
 import { match, P } from 'ts-pattern'
+import { ORDER_QUERY_ITEMS } from './sort/SortingForm'
 
 type Props = {
   items: RelistItem[]
@@ -35,8 +36,9 @@ const useFilterItems = (items: RelistItem[]) => {
   const searchParams = useSearchParams()
   return items.filter(item => {
     const toBeFiltered: boolean[] = []
+
     searchParams.forEach((value: string, key: string) => {
-      if (['orderBy', 'sort'].includes(key)) {
+      if (ORDER_QUERY_ITEMS.includes(key)) {
         return
       }
       const [min, max] = value.split(SEPARATOR).map(it => Number(it))
@@ -139,11 +141,10 @@ export default function List({ items: rawItems, attributes }: Props) {
         <ItemList
           key={`${item[camelCase(titleAttrs[0].title)]}`}
           title={titleAttrs?.map(attr => item[camelCase(attr.title)]) as string[]}
-          footer={tagsAttrs?.flatMap(
-            attr =>
-              (item[camelCase(attr.title)] as string)
-                ?.split(',')
-                ?.map(tag => <Badge key={tag}>{tag}</Badge>),
+          footer={tagsAttrs?.flatMap(attr =>
+            (item[camelCase(attr.title)] as string)
+              ?.split(',')
+              ?.map(tag => <Badge key={tag}>{tag}</Badge>),
           )}
         >
           <PrimaryBlock item={item} attributes={attributes.primary} />

--- a/app/[sheetId]/NavBar.tsx
+++ b/app/[sheetId]/NavBar.tsx
@@ -4,6 +4,8 @@ import { useQueryString } from '@/lib/utils'
 import { Toggle } from '@radix-ui/react-toggle'
 import Link from 'next/link'
 import Image from 'next/image'
+import { useMemo } from 'react'
+import { ORDER_QUERY_ITEMS } from './sort/SortingForm'
 
 const MenuItem = ({
   path,
@@ -28,14 +30,25 @@ const MenuItem = ({
 }
 
 export const NavBar = () => {
-  const { params, query, pathname } = useQueryString()
+  const { query } = useQueryString()
+  const hasActiveFilters = useMemo(
+    () =>
+      Array.from(new URLSearchParams(query).keys()).filter(
+        key => !ORDER_QUERY_ITEMS.includes(key),
+      ),
+    [query],
+  )
 
   return (
     <menu className="m-4 justify-between items-start flex text-white-100">
       <MenuItem
         path="filter"
         onIcon="/icon/filter=on.svg"
-        offIcon="/icon/filter=off.svg"
+        offIcon={
+          hasActiveFilters.length > 0
+            ? '/icon/filter=off-active.svg'
+            : '/icon/filter=off.svg'
+        }
         title="Filters"
       />
 

--- a/app/[sheetId]/sort/SortingForm.tsx
+++ b/app/[sheetId]/sort/SortingForm.tsx
@@ -11,6 +11,13 @@ import { camelCase } from 'lodash'
 
 const OrderEnum = z.enum(['asc', 'desc'])
 
+export const OrderQueryItem = {
+  OrderBy: 'orderBy',
+  Sort: 'sort',
+}
+
+export const ORDER_QUERY_ITEMS = Object.values(OrderQueryItem)
+
 type Props = {
   attributes: AttributeItem[]
 }
@@ -34,9 +41,11 @@ export function SortingForm({ attributes }: Props) {
 
       <RadioGroup
         onValueChange={value =>
-          router.replace(pathname + '?' + createQueryString('orderBy', value))
+          router.replace(
+            pathname + '?' + createQueryString(OrderQueryItem.OrderBy, value),
+          )
         }
-        defaultValue={searchParams.get('orderBy') ?? undefined}
+        defaultValue={searchParams.get(OrderQueryItem.OrderBy) ?? undefined}
         className="flex flex-col space-y-1"
       >
         {attributes.map(attribute => (
@@ -51,9 +60,9 @@ export function SortingForm({ attributes }: Props) {
 
       <RadioGroup
         onValueChange={value =>
-          router.replace(pathname + '?' + createQueryString('sort', value))
+          router.replace(pathname + '?' + createQueryString(OrderQueryItem.Sort, value))
         }
-        defaultValue={searchParams.get('sort') ?? undefined}
+        defaultValue={searchParams.get(OrderQueryItem.Sort) ?? undefined}
         className="flex flex-col space-y-1"
       >
         {OrderEnum.options.map(it => (

--- a/lib/relistData.ts
+++ b/lib/relistData.ts
@@ -1,5 +1,5 @@
 import { match, P } from 'ts-pattern'
-import { camelCase, mapValues, maxBy, minBy, range, pickBy } from 'lodash'
+import { camelCase, mapValues, range, pickBy } from 'lodash'
 import { getDataFromSheet } from './sheets'
 import { AttributeItem } from '@/components/Attributes'
 import { unstable_cache } from 'next/cache'


### PR DESCRIPTION
<img width="559" alt="image" src="https://github.com/dbertella/relist/assets/2563196/4b5ea42b-e93a-4ad4-99df-0cdbfeff5b63">
This closes #46 

there are two small issues, 
1. we don't have an active filtered icon (or at least not in the codebase) so when in filter tab you see the normal one even if you have active filters
![image](https://github.com/dbertella/relist/assets/2563196/a3a2fd01-8b54-4ce8-8c2c-61a008ef1adb)
2. when you manually reset filters to the max / min you are still filtering for the sake of the app, so you will still see this icon until you'll press on reset filters button