### PR TITLE
Add link block based on markdown links in sheet

### DIFF
--- a/app/[sheetId]/List.tsx
+++ b/app/[sheetId]/List.tsx
@@ -124,6 +124,37 @@ const ImageBlock = ({
     : null
 }
 
+/* Match full links and relative paths */
+const regex = /^\[([\w\s\d]+)\]\(((?:\/|https?:\/\/)[\w\d./?=#]+)\)$/
+
+const LinkBlock = ({
+  attributes,
+  item,
+}: {
+  attributes: AttributeItem[]
+  item: RelistItem
+}) => {
+  const values = attributes
+    ?.map((attr: AttributeItem) => ({
+      ...attr,
+      itemValue: getAttributeValue(item[camelCase(attr.title)]),
+    }))
+    .filter(filterNonNullValues)
+
+  return values?.length > 0
+    ? values.map(it => {
+        const myMatch = it.itemValue.match(regex)
+
+        console.log(myMatch)
+        return (
+          <div key={it.title} className="text-accent">
+            <a href={myMatch?.[2] ?? '#'}>{myMatch?.[1]}</a>
+          </div>
+        )
+      })
+    : null
+}
+
 export default function List({ items: rawItems, attributes }: Props) {
   const searchParams = useSearchParams()
 
@@ -175,6 +206,7 @@ export default function List({ items: rawItems, attributes }: Props) {
           ))}
 
           <ImageBlock attributes={attributes[AttributeType.Imageurl]} item={item} />
+          <LinkBlock attributes={attributes[AttributeType.Link]} item={item} />
         </ItemList>
       ))}
     </>


### PR DESCRIPTION
<img width="453" alt="image" src="https://github.com/dbertella/relist/assets/2563196/d5802b6d-7eae-40e1-9432-334356c15893">

The link will look like in the screenshot, and it's expecting markdown syntax in the spreadsheet (not ideal).
I tired adding a link in the sheet but only the title is returned in the apis. Not sure if there is a better way

This relates to #50 (missing css)