### PR TITLE
rename of the template's sheets

### DIFF
--- a/app/[sheetId]/NavBar.tsx
+++ b/app/[sheetId]/NavBar.tsx
@@ -43,6 +43,12 @@ export const NavBar = () => {
     <div className="sticky top-0 z-10 w-full bg-level1-100">
       <menu className="p-4 justify-between items-start flex">
         <MenuItem
+          path="details"
+          onIcon="/icon/details=on.svg"
+          offIcon="/icon/details=off.svg"
+          title="Filters"
+        />
+        <MenuItem
           path="filter"
           onIcon="/icon/filter=on.svg"
           offIcon={
@@ -58,12 +64,6 @@ export const NavBar = () => {
           onIcon="/icon/sort=on.svg"
           offIcon="/icon/sort=off.svg"
           title="Sort"
-        />
-        <MenuItem
-          path="details"
-          onIcon="/icon/details=on.svg"
-          offIcon="/icon/details=off.svg"
-          title="Filters"
         />
 
         <MenuItem

--- a/app/[sheetId]/details/page.tsx
+++ b/app/[sheetId]/details/page.tsx
@@ -11,7 +11,7 @@ export default async function Page({ params }: PageProps) {
   const attributes = groupBy(meta, it =>
     match(it.type)
       .with(P.union('number', 'range'), () => {
-        return it.inPreview === 'yes' ? 'primary' : 'secondary'
+        return it.showInPreview === 'yes' ? 'primary' : 'secondary'
       })
       .with('title', () => 'title')
       .with('tags', () => 'tags')

--- a/app/[sheetId]/layout.tsx
+++ b/app/[sheetId]/layout.tsx
@@ -18,11 +18,11 @@ export default async function PageLayout({
   return (
     <main className="max-w-2xl m-auto px-4 leading-normal">
       <Card className="py-4 px-1 border-none rounded-none bg-level2">
-        <H3>A {info.author}&apos;s list</H3>
+        <H3>A {info.owner}&apos;s list</H3>
         <div className={alfa_slab_one.className}>
-          <H1>{info.title}</H1>
+          <H1>{info.titleForThisRelist}</H1>
         </div>
-        <H2>{info.description}</H2>
+        <H2>{info.descriptionForThisRelist}</H2>
       </Card>
 
       <NavBar />

--- a/app/[sheetId]/page.tsx
+++ b/app/[sheetId]/page.tsx
@@ -11,7 +11,7 @@ export default async function Page({ params }: PageProps) {
   const attributes = groupBy(meta, it =>
     match(it.type)
       .with(P.union('number', 'range'), () => {
-        return it.inPreview === 'yes' ? 'primary' : 'secondary'
+        return it.showInPreview === 'yes' ? 'primary' : 'secondary'
       })
       .with('title', () => 'title')
       .with('tags', () => 'tags')

--- a/components/Attributes.tsx
+++ b/components/Attributes.tsx
@@ -21,7 +21,7 @@ export type AttributeItem = {
   showMax: string
   unit: string
   size: string
-  inPreview: 'yes' | 'no'
+  showInPreview: 'yes' | 'no'
   value: string | null
   className?: string
 }

--- a/lib/relistData.ts
+++ b/lib/relistData.ts
@@ -15,7 +15,7 @@ export const getRelistData = unstable_cache(
       info.nameOfTheSheetContainingTheData,
     )
 
-    const metaMap = Object.fromEntries(meta.map(it => [camelCase(it.title), it]))
+    const metaMap = Object.fromEntries(meta.map(it => [camelCase(it.columnName), it]))
 
     const parsedItems = items.map(it =>
       pickBy(
@@ -35,7 +35,7 @@ export const getRelistData = unstable_cache(
     ) as RelistItem[]
 
     const parsedMeta = meta.map(property => {
-      const key = camelCase(property.title)
+      const key = camelCase(property.columnName)
       const range = parsedItems
         .flatMap(it => it[key])
         .filter(Boolean)
@@ -44,6 +44,7 @@ export const getRelistData = unstable_cache(
       const max = range.at(-1)
       return {
         ...property,
+        title: property.columnName,
         ...match(property.type)
           .with(P.union('number', 'range'), () => {
             return {

--- a/lib/relistData.ts
+++ b/lib/relistData.ts
@@ -8,9 +8,12 @@ export type RelistItem = Record<string, string | number | number[]>
 
 export const getRelistData = unstable_cache(
   async (spreadsheetId: string) => {
-    const [info] = await getDataFromSheet(spreadsheetId, 'info')
-    const meta = await getDataFromSheet(spreadsheetId, info.sheetForListSetup)
-    const items = await getDataFromSheet(spreadsheetId, info.sheetForListData)
+    const [info] = await getDataFromSheet(spreadsheetId, 'Relist info')
+    const meta = await getDataFromSheet(spreadsheetId, 'Relist setup')
+    const items = await getDataFromSheet(
+      spreadsheetId,
+      info.nameOfTheSheetContainingTheData,
+    )
 
     const metaMap = Object.fromEntries(meta.map(it => [camelCase(it.title), it]))
 
@@ -61,6 +64,6 @@ export const getRelistData = unstable_cache(
   },
   ['full-data'],
   {
-    revalidate: 180,
+    revalidate: 10,
   },
 )


### PR DESCRIPTION
- column's name renamed: author --> owner
- column's name renamed: description --> description for this relist
- sheet renamed according to the template : info --> Relist info
- sheet renamed according to the template : info.sheetForListData --> 'Relist setup'
- menu's eye icon moved on the left.